### PR TITLE
Fixed mp3 as the only audio master and fixed version check to accept …

### DIFF
--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -18,13 +18,14 @@ func checkVersion() {
 		fmt.Println("Unable to find ffmpeg in your path")
 	} else {
 		// Find out what version of ffmpeg that is installed
-		version := regexp.MustCompile(`ffmpeg.version.\d\S*`)
-		re := regexp.MustCompile("ffmpeg.version 3")
+		Findversion := regexp.MustCompile(`ffmpeg.version.[3-4]`)
+    version := Findversion.FindString( string(out[:30] ) )
+		re := regexp.MustCompile("ffmpeg.version [3-4]")
 
 		bFound := re.MatchString(string(out[:30]))
 		if bFound == false {
 			//found but wrong version
-			fmt.Printf("Requires ffmpeg >= 3.x.x I found version %s", version)
+			fmt.Printf("Requires ffmpeg >= 3.x - I found version %s", version)
 			fmt.Println("Go here to download binaries for your machine: https://ffmpeg.org/download.html")
 			fmt.Println("I would recommend the static compiled version")
 			err = errors.New("Wrong version of ffmpeg found ")
@@ -67,8 +68,9 @@ func checkFFmpegVersion() error {
 		fmt.Println(err)
 	} else {
 		// Find out what version of ffmpeg that is installed
-		version := regexp.MustCompile(`ffmpeg.version.\d\S*`)
-		re := regexp.MustCompile("ffmpeg.version 3")
+		FindVersion := regexp.MustCompile(`ffmpeg.version.[3-4]`)
+    version := FindVersion.FindString( string(out[:30] ) )
+		re := regexp.MustCompile("ffmpeg.version [3-4]")
 
 		bFound := re.MatchString(string(out[:30]))
 		if bFound == false {

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var (
 func main() {
 	var ()
 
-	kingpin.Version("0.0.4")
+	kingpin.Version("0.0.5")
 	app.UsageTemplate(kingpin.SeparateOptionalFlagsUsageTemplate)
 
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {

--- a/suggest.go
+++ b/suggest.go
@@ -126,6 +126,9 @@ func masterAudio(fileStreams []*ffprobe.Stream) (streamIndex int, err error) {
 				switch stream.CodecName {
 				case "truehd":
 					fallthrough
+        case "mp3":
+          streamIndex = stream.Index
+          return
 				case "dts":
 					streamIndex = stream.Index
 					return
@@ -195,6 +198,9 @@ func (media *Convert) setupAudioConversion(fileStreams []*ffprobe.Stream) {
 		case "dts":
 			media.outAudio0 = "convert"
 			media.outAudio1 = "none"
+    case "mp3":
+      media.outAudio0 = "convert"
+      media.outAudio1 = "none"
 		default:
 			fmt.Printf("Not sure what to do with this codec: %s", media.masterAudioStream.CodecName)
 


### PR DESCRIPTION
- Fixed an issue where if the only audio was an mp3 audio we wouldn't know what to do with it.  Now we convert it to aac.
- Also fixed an issue where we would bomb out if ffmpeg was version 4.  We now accept version 3 and version 4 of ffmpeg.